### PR TITLE
Fix interpolating nan values

### DIFF
--- a/vame/model/create_training.py
+++ b/vame/model/create_training.py
@@ -34,7 +34,9 @@ def temporal_traindata(cfg, files, testfraction, num_features, savgol_filter):
     seq_inter = np.zeros((X.shape[0],X.shape[1]))
     for s in range(num_features):
         seq_temp = X[s,:]
-        seq_pd = pd.Series(seq_temp)  
+        seq_pd = pd.Series(seq_temp)
+        if np.isnan(seq_pd[0]):
+            seq_pd[0] = next(x for x in seq_pd if not np.isnan(x))
         seq_pd_inter = seq_pd.interpolate(method="linear", order=None)
         seq_inter[s,:] = seq_pd_inter
     


### PR DESCRIPTION
Interpolation of body part positions starting with nan values is not possible (for all nan values up to the first non-nan value). These values stay as nan values. This leads to a "numpy.linalg.LinAlgError: SVD did not converge in Linear Least Squares" error when executing the savgol filter.

This pull request fixes this by replacing the first nan value with the first non-nan value in the series for each body part, if the series starts with a nan value.