### PR TITLE
Ensure all empty motifs present in motif_usage.npy

### DIFF
--- a/vame/analysis/behavior_structure.py
+++ b/vame/analysis/behavior_structure.py
@@ -75,9 +75,19 @@ def get_network(path_to_file, file, cluster_method, n_cluster):
     motif_usage = np.unique(labels, return_counts=True)
     cons = consecutive(motif_usage[0])
     if len(cons) != 1:
+        used_motifs = list(motif_usage[0])
         usage_list = list(motif_usage[1])
-        index = cons[0][-1]+1
-        usage_list.insert(index,0)
+        
+        for i in range(n_cluster):
+            if i not in used_motifs:
+                used_motifs.insert(i, i)
+                usage_list.insert(i,0)
+        
+   #     for i in range(len(cons)):
+   #         index = cons[i][-1]+1
+   #         usage_list.insert(index,0)
+   #         if index != cons[i+1][-1]+1:
+   #             usage_list.insert(index+1,0)
     
         usage = np.array(usage_list)
     


### PR DESCRIPTION
Hello,

This pull request focuses on the behavior_stucture.py script, specifically the 'get_network' function. In it's current state, this function attempts to fill empty clusters by detecting gaps in consecutive cluster numbers, and if len(cons) != 0, it fills:

```
index = cons[i][-1]+1
usage_list.insert(index,0)
```

However this breaks if there are multiple consecutive missing clusters. For example if clusters 14,15,16 are all empty, it will fill 14 with 0, but will leave 15 and 16 empty. The edited code in this PR will ensure all clusters are present and fill with 0 if not.

Thanks,
Alex