### PR TITLE
minor fix for file_format & easy reinstall.sh

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,0 +1,3 @@
+pip uninstall vame
+python3 setup.py sdist bdist_wheel
+pip install dist/vame-1.0-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="vame",
-    version='0.1',
+    version='1.0',
     packages=find_packages(),
     entry_points={"console_scripts": "vame = vame:main"},
     author="K. Luxem & P. Bauer",

--- a/vame/initialize_project/new.py
+++ b/vame/initialize_project/new.py
@@ -31,29 +31,29 @@ def init_new_project(project, videos, working_directory=None, videotype='.mp4'):
     year = date.year
     d = str(month[0:3]+str(day))
     date = dt.today().strftime('%Y-%m-%d')
-    
+
     if working_directory == None:
         working_directory = '.'
-        
+
     wd = Path(working_directory).resolve()
-    project_name = '{pn}-{date}'.format(pn=project, date=d+'-'+str(year)) 
-    
+    project_name = '{pn}-{date}'.format(pn=project, date=d+'-'+str(year))
+
     project_path = wd / project_name
-    
-    
+
+
     if project_path.exists():
         print('Project "{}" already exists!'.format(project_path))
         return
-    
+
     video_path = project_path / 'videos'
     data_path = project_path / 'data'
     results_path = project_path / 'results'
     model_path = project_path / 'model'
-    
+
     for p in [video_path, data_path, results_path, model_path]:
         p.mkdir(parents=True)
         print('Created "{}"'.format(p))
-    
+
     vids = []
     for i in videos:
         #Check if it is a folder
@@ -70,8 +70,8 @@ def init_new_project(project, videos, working_directory=None, videotype='.mp4'):
             if os.path.isfile(i):
                 vids = vids + [i]
             videos = vids
-            
-            
+
+
     videos = [Path(vp) for vp in videos]
     video_names = []
     dirs_data = [data_path/Path(i.stem) for i in videos]
@@ -81,26 +81,26 @@ def init_new_project(project, videos, working_directory=None, videotype='.mp4'):
         """
         p.mkdir(parents = True, exist_ok = True)
         video_names.append(p.stem)
-        
+
     dirs_results = [results_path/Path(i.stem) for i in videos]
     for p in dirs_results:
         """
         Creates directory under results
         """
         p.mkdir(parents = True, exist_ok = True)
-        
+
     destinations = [video_path.joinpath(vp.name) for vp in videos]
-    
+
     os.mkdir(str(project_path)+'/'+'videos/pose_estimation/')
     os.mkdir(str(project_path)+'/model/pretrained_model')
-           
+
     print("Copying the videos \n")
     for src, dst in zip(videos, destinations):
         shutil.copy(os.fspath(src),os.fspath(dst))
 
     cfg_file,ruamelFile = auxiliary.create_config_template()
     cfg_file
-    
+
     cfg_file['Project']=str(project)
     cfg_file['project_path']=str(project_path)+'/'
     cfg_file['test_fraction']=0.1
@@ -108,8 +108,8 @@ def init_new_project(project, videos, working_directory=None, videotype='.mp4'):
     cfg_file['all_data']='yes'
     cfg_file['load_data']='-PE-seq-clean'
     cfg_file['anneal_function']='linear'
-    cfg_file['batch_size']=256 
-    cfg_file['max_epochs']=500 
+    cfg_file['batch_size']=256
+    cfg_file['max_epochs']=500
     cfg_file['transition_function']='GRU'
     cfg_file['beta']=1
     cfg_file['zdims']=30
@@ -153,23 +153,14 @@ def init_new_project(project, videos, working_directory=None, videotype='.mp4'):
     cfg_file['random_state'] = 42
     cfg_file['num_points'] = 30000
     cfg_file['scheduler_gamma'] = 0.2
-    
+
     projconfigfile=os.path.join(str(project_path),'config.yaml')
     # Write dictionary to yaml  config file
     auxiliary.write_config(projconfigfile,cfg_file)
-    
+
     print('A VAME project has been created. \n'
           '\n'
           'Next use vame.create_trainset(config) to split your data into a train and test set. \n'
-          'Afterwards you can use vame.rnn_model() to train the model on your data.')
-    
+          'Afterwards you can use vame.train_model() to train the model on your data.')
+
     return projconfigfile
-    
-    
-    
-    
-    
-    
-            
-            
-            

--- a/vame/util/csv_to_npy.py
+++ b/vame/util/csv_to_npy.py
@@ -14,30 +14,30 @@ import numpy as np
 import pandas as pd
 
 from pathlib import Path
-from vame.util.auxiliary import read_config  
+from vame.util.auxiliary import read_config
 
 def csv_to_numpy(config, datapath):
     """
-    This is a demo function to show how a conversion from the resulting pose-estimation.csv file
-    to a numpy array can be implemented.
+    This is a function to convert your pose-estimation.csv file to a numpy array.
+
     Note that this code is only useful for data which is a priori egocentric, i.e. head-fixed
     or otherwise restrained animals.
 
-    example:
-    vame.csv_to_npy('your/CSVfile/path', 'path/you/want/it/togo')
+    example use:
+    vame.csv_to_npy('pathto/your/config/yaml', 'path/toYourFolderwithCSV/')
     """
     config_file = Path(config).resolve()
     cfg = read_config(config_file)
-    
+
     path_to_file = cfg['project_path']
     filename = cfg['video_sets']
-    
+
     for file in filename:
         # Read in your .csv file, skip the first two rows and create a numpy array
         data = pd.read_csv(datapath+file+'.csv', skiprows = 2)
         data_mat = pd.DataFrame.to_numpy(data)
         data_mat = data_mat[:,1:]
-    
+
         # get the number of bodyparts, their x,y-position and the confidence from DeepLabCut
         bodyparts = int(np.size(data_mat[0,:]) / 3)
         positions = []
@@ -47,10 +47,10 @@ def csv_to_numpy(config, datapath):
             positions.append(data_mat[:,idx:idx+2])
             confidence.append(data_mat[:,idx+2])
             idx += 3
-    
+
         body_position = np.concatenate(positions, axis=1)
         con_arr = np.array(confidence)
-    
+
         # find low confidence and set them to NaN (vame.create_trainset(config) will interpolate these NaNs)
         body_position_nan = []
         idx = -1
@@ -60,9 +60,9 @@ def csv_to_numpy(config, datapath):
             seq = body_position[:,i]
             seq[con_arr[idx,:]<.99] = np.NaN
             body_position_nan.append(seq)
-    
+
         final_positions = np.array(body_position_nan)
-    
+
         # save the final_positions array with np.save()
         np.save(os.path.join(path_to_file,'data',file,file+"-PE-seq.npy"), final_positions)
         print("conversion from DeepLabCut csv to numpy complete...")

--- a/vame/util/gif_pose_helper.py
+++ b/vame/util/gif_pose_helper.py
@@ -24,72 +24,72 @@ def crop_and_flip(rect, src, points, ref_index):
     #Read out rect structures and convert
     center, size, theta = rect
     center, size = tuple(map(int, center)), tuple(map(int, size))
-    #Get rotation matrix 
+    #Get rotation matrix
     M = cv.getRotationMatrix2D(center, theta, 1)
-       
+
     #shift DLC points
     x_diff = center[0] - size[0]//2
     y_diff = center[1] - size[1]//2
-    
+
     dlc_points_shifted = []
-    
+
     for i in points:
         point=cv.transform(np.array([[[i[0], i[1]]]]),M)[0][0]
 
         point[0] -= x_diff
         point[1] -= y_diff
-        
+
         dlc_points_shifted.append(point)
-        
+
     # Perform rotation on src image
     dst = cv.warpAffine(src.astype('float32'), M, src.shape[:2])
     out = cv.getRectSubPix(dst, size, center)
-    
+
     #check if flipped correctly, otherwise flip again
     if dlc_points_shifted[ref_index[1]][0] >= dlc_points_shifted[ref_index[0]][0]:
         rect = ((size[0]//2,size[0]//2),size,180)
         center, size, theta = rect
         center, size = tuple(map(int, center)), tuple(map(int, size))
-        #Get rotation matrix 
+        #Get rotation matrix
         M = cv.getRotationMatrix2D(center, theta, 1)
-        
-        
+
+
         #shift DLC points
         x_diff = center[0] - size[0]//2
         y_diff = center[1] - size[1]//2
-        
+
         points = dlc_points_shifted
         dlc_points_shifted = []
-        
+
         for i in points:
             point=cv.transform(np.array([[[i[0], i[1]]]]),M)[0][0]
-    
+
             point[0] -= x_diff
             point[1] -= y_diff
-            
+
             dlc_points_shifted.append(point)
-    
+
         # Perform rotation on src image
         dst = cv.warpAffine(out.astype('float32'), M, out.shape[:2])
         out = cv.getRectSubPix(dst, size, center)
-        
+
     return out, dlc_points_shifted
 
 
 def background(path_to_file,filename,file_format='.mp4',num_frames=1000):
     """
-    Compute background image from fixed camera 
+    Compute background image from fixed camera
     """
-    
+
     capture = cv.VideoCapture(os.path.join(path_to_file,"videos",filename+file_format))
-    
+
     if not capture.isOpened():
         raise Exception("Unable to open video file: {0}".format(os.path.join(path_to_file,"videos",filename+file_format)))
-        
+
     frame_count = int(capture.get(cv.CAP_PROP_FRAME_COUNT))
     ret, frame = capture.read()
-    
-    height, width, _ = frame.shape    
+
+    height, width, _ = frame.shape
     frames = np.zeros((height,width,num_frames))
 
     for i in tqdm.tqdm(range(num_frames), disable=not True, desc='Compute background image for video %s' %filename):
@@ -98,54 +98,54 @@ def background(path_to_file,filename,file_format='.mp4',num_frames=1000):
         ret, frame = capture.read()
         gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
         frames[...,i] = gray
-    
+
     print('Finishing up!')
     medFrame = np.median(frames,2)
     background = scipy.ndimage.median_filter(medFrame, (5,5))
-    
+
     np.save(os.path.join(path_to_file,"videos",filename+'-background.npy'),background)
-    
+
     capture.release()
     return background
 
 
 def get_rotation_matrix(adjacent, opposite, crop_size=(300, 300)):
-    
+
     tan_alpha = np.abs(opposite) / np.abs(adjacent)
     alpha = np.arctan(tan_alpha)
     alpha = np.rad2deg(alpha)
-    
+
     if adjacent < 0 and opposite > 0:
         alpha = 180-alpha
-    
+
     if adjacent  < 0 and opposite < 0:
         alpha = -(180-alpha)
-        
+
     if adjacent > 0 and opposite < 0:
         alpha = -alpha
-    
+
     rot_mat = cv.getRotationMatrix2D((crop_size[0] // 2, crop_size[1] // 2),alpha, 1)
-    
+
     return rot_mat
 
 
-#Helper function to return indexes of nans        
+#Helper function to return indexes of nans
 def nan_helper(y):
-    return np.isnan(y), lambda z: z.nonzero()[0] 
+    return np.isnan(y), lambda z: z.nonzero()[0]
 
 
 #Interpolates all nan values of given array
 def interpol(arr):
-        
+
     y = np.transpose(arr)
-     
+
     nans, x = nan_helper(y[0])
-    y[0][nans]= np.interp(x(nans), x(~nans), y[0][~nans])   
+    y[0][nans]= np.interp(x(nans), x(~nans), y[0][~nans])
     nans, x = nan_helper(y[1])
     y[1][nans]= np.interp(x(nans), x(~nans), y[1][~nans])
-    
+
     arr = np.transpose(y)
-    
+
     return arr
 
 
@@ -156,23 +156,23 @@ def get_animal_frames(cfg, filename, pose_ref_index, start, length, subtract_bac
     #read out data
     data = pd.read_csv(os.path.join(path_to_file,"videos","pose_estimation",filename+'.csv'), skiprows = 2)
     data_mat = pd.DataFrame.to_numpy(data)
-    data_mat = data_mat[:,1:] 
-    
+    data_mat = data_mat[:,1:]
+
     # get the coordinates for alignment from data table
     pose_list = []
-    
+
     for i in range(int(data_mat.shape[1]/3)):
-        pose_list.append(data_mat[:,i*3:(i+1)*3])  
-        
+        pose_list.append(data_mat[:,i*3:(i+1)*3])
+
     #list of reference coordinate indices for alignment
-    #0: snout, 1: forehand_left, 2: forehand_right, 
-    #3: hindleft, 4: hindright, 5: tail    
-    
+    #0: snout, 1: forehand_left, 2: forehand_right,
+    #3: hindleft, 4: hindright, 5: tail
+
     pose_ref_index = pose_ref_index
-    
+
     #list of 2 reference coordinate indices for avoiding flipping
     pose_flip_ref = pose_ref_index
-    
+
     # compute background
     if subtract_background == True:
         try:
@@ -180,24 +180,24 @@ def get_animal_frames(cfg, filename, pose_ref_index, start, length, subtract_bac
             bg = np.load(os.path.join(path_to_file,"videos",filename+'-background.npy'))
         except:
             print("Can't find background image... Calculate background image...")
-            bg = background(path_to_file,filename)
-    
+            bg = background(path_to_file,filename, file_format)
+
     images = []
-    points = [] 
+    points = []
      
-    for i in pose_list:       
+    for i in pose_list:
         for j in i:
             if j[2] <= 0.8:
-                j[0],j[1] = np.nan, np.nan      
-                
+                j[0],j[1] = np.nan, np.nan
+
 
     for i in pose_list:
         i = interpol(i)
-         
+
     capture = cv.VideoCapture(os.path.join(path_to_file,"videos",filename+file_format))
     if not capture.isOpened():
         raise Exception("Unable to open video file: {0}".format(os.path.join(path_to_file,"videos",filename++file_format)))
-    
+
     for idx in tqdm.tqdm(range(length), disable=not True, desc='Align frames'):
         try:
             capture.set(1,idx+start+lag)
@@ -209,15 +209,15 @@ def get_animal_frames(cfg, filename, pose_ref_index, start, length, subtract_bac
         except:
             print("Couldn't find a frame in capture.read(). #Frame: %d" %idx+start+lag)
             continue
-        
+
        #Read coordinates and add border
         pose_list_bordered = []
-                
+
         for i in pose_list:
             pose_list_bordered.append((int(i[idx+start+lag][0]+crop_size[0]),int(i[idx+start+lag][1]+crop_size[1])))
-        
+
         img = cv.copyMakeBorder(frame, crop_size[1], crop_size[1], crop_size[0], crop_size[0], cv.BORDER_CONSTANT, 0)
-        
+
         punkte = []
         for i in pose_ref_index:
             coord = []
@@ -226,39 +226,22 @@ def get_animal_frames(cfg, filename, pose_ref_index, start, length, subtract_bac
             punkte.append(coord)
         punkte = [punkte]
         punkte = np.asarray(punkte)
-        
+
         #calculate minimal rectangle around snout and tail
         rect = cv.minAreaRect(punkte)
-    
+
         #change size in rect tuple structure to be equal to crop_size
         lst = list(rect)
         lst[1] = crop_size
         rect = tuple(lst)
-        
+
         center, size, theta = rect
-        
+
         #crop image
         out, shifted_points = crop_and_flip(rect, img,pose_list_bordered,pose_flip_ref)
-        
+
         images.append(out)
         points.append(shifted_points)
-        
+
     capture.release()
     return images
-
-
-
-
-
-
-
- 
- 
- 
- 
- 
- 
-
-
-
-


### PR DESCRIPTION
I ran into a minor issue with not being able to pass non-mp4 files  to `vame.gif` (always looked for `mp4` if `subtract_background =True`). Here is the simple fix! (Also, the formatting is auto-fixed in atom-- apologies, not sure how to not fix it ... )

I also added a reinstall.sh script (simply run `./reinstall.sh` in the VAME folder for fast uninstall / reinstall for testing).

I bumped your setu.py to 1.0 since you mention this in your release ;)

Also, behavior of convert csv to numpy changed, so I updated the docstring to reflect this.