### PR TITLE
Small changes to scheduler threshold

### DIFF
--- a/vame/util/auxiliary.py
+++ b/vame/util/auxiliary.py
@@ -71,6 +71,9 @@ def create_config_template():
     scheduler:
     scheduler_step_size:
     scheduler_gamma:
+    #Note the optimal scheduler threshold below can vary greatly (from .1-.0001) between experiments. 
+    #You are encouraged to read the torch.optim.ReduceLROnPlateau docs to understand the threshold to use.
+    scheduler_threshold:
     softplus: 
     \n
 # Segmentation:
@@ -231,7 +234,7 @@ def update_config(config):
         cfg_file['n_neighbors'] = 200
         cfg_file['random_state'] = 42
         cfg_file['num_points'] = 30000
-        cfg_file['scheduler_gamma'] = 0.2
+        cfg_file['scheduler_threshold'] = .1
         cfg_file['softplus'] = False
         cfg_file['pose_confidence'] = 0.99
         cfg_file['iqr_factor'] = 4


### PR DESCRIPTION
The optimal scheduler threshold parameter can vary greatly between experiments (from .1 to .0001), depending on the order of magnitude of the loss values. In this PR I changed the default to .1, and added comments in config.yaml to encourage users to read the docs on torch.optim.ReduceLROnPlateau to understand this parameter.