### PR TITLE
Allow resuming training by passing full path to pretrained_model

### DIFF
--- a/vame/model/rnn_vae.py
+++ b/vame/model/rnn_vae.py
@@ -316,6 +316,8 @@ def train_model(config):
             try:
                 print("Loading pretrained weights from %s\n" %pretrained_model)
                 model.load_state_dict(torch.load(pretrained_model))
+                KL_START = 0
+                ANNEALTIME = 1
             except:
                 print("Could not load pretrained model. Check file path in config.yaml.")
             

--- a/vame/model/rnn_vae.py
+++ b/vame/model/rnn_vae.py
@@ -306,11 +306,18 @@ def train_model(config):
                         dropout_rec, dropout_pred, softplus).to()
 
     if pretrained_weights:
-        if os.path.exists(os.path.join(cfg['project_path'],'model','best_model',pretrained_model+'_'+cfg['Project']+'.pkl')): 
-            print("Loading pretrained weights from model: %s\n" %pretrained_model)
+        try:
+            print("Loading pretrained weights from model: %s\n" %os.path.join(cfg['project_path'],'model','best_model',pretrained_model+'_'+cfg['Project']+'.pkl'))
             model.load_state_dict(torch.load(os.path.join(cfg['project_path'],'model','best_model',pretrained_model+'_'+cfg['Project']+'.pkl')))
             KL_START = 0
             ANNEALTIME = 1
+        except:
+            print("No file found at %s\n" %os.path.join(cfg['project_path'],'model','best_model',pretrained_model+'_'+cfg['Project']+'.pkl'))
+            try:
+                print("Loading pretrained weights from %s\n" %pretrained_model)
+                model.load_state_dict(torch.load(pretrained_model))
+            except:
+                print("Could not load pretrained model. Check file path in config.yaml.")
             
     """ DATASET """
     trainset = SEQUENCE_DATASET(os.path.join(cfg['project_path'],"data", "train",""), data='train_seq.npy', train=True, temporal_window=TEMPORAL_WINDOW)


### PR DESCRIPTION
This commit enables loading a pretrained model from a full model path specified in config.yaml, instead of needing to specify only the model name and not the full path. This makes the syntax more consistent with DeepLabCut, where model weights are restored by passing a full path to a snapshot. This commit first tries to load the model based on the specified pretrained_model argument in the project_path/model/best_model directory (as the code does before this commit), and if it can't find that (i.e. the user put something other than the model_name to load), then it tries to load a full file path. If it can't find that, it errors. 

Ending in a FileNotFound error is preferred because with the current state of the repo, if the user puts in an invalid path, it will not load the pretrained_model, but doesn't make it totally clear that it is starting fresh. By resulting in an error the user is forced to put a valid model_name, file path, or None.