### PR TITLE
Replace deprecated 'sklearn' by 'scikit-learn'

### DIFF
--- a/VAME.yaml
+++ b/VAME.yaml
@@ -20,7 +20,7 @@ dependencies:
     - pathlib
     - pandas
     - ruamel.yaml
-    - sklearn
+    - scikit-learn
     - pyyaml
     - opencv-python-headless
     - h5py

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "pathlib",
 	"pandas",
         "ruamel.yaml",
-	"sklearn",
+	"scikit-learn",
         "pyyaml",
         "opencv-python",
     ],


### PR DESCRIPTION
Updated the conda env and setup.py files to use `scikit-learn` (relates to #129)